### PR TITLE
Add usage guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # Persoshift
-Personal Development Website
+
+Persoshift is a simple personal development and finance tool. The main page `index.html` provides an ETF savings plan calculator with charts and information pop-ups.
+
+## Features
+- Interactive ETF savings plan calculator
+- Monthly contributions with optional annual increases
+- Add one-time deposits and configure payout plans
+- Net vs. gross calculations with German capital gains tax support
+- Charts comparing ETF performance to a savings account
+- Info modals explaining ETFs, taxes and related topics
+
+## Getting Started
+Clone the repository and open or serve `index.html`.
+
+```bash
+git clone https://github.com/mahodesin/Persoshift.git
+cd Persoshift
+```
+
+### Running via HTTP server
+Serving the file avoids browser security warnings. The example below uses Python:
+
+```bash
+python3 -m http.server
+```
+
+Open `http://localhost:8000/index.html` in your browser.
+
+### Direct browser open
+You can also double-click `index.html` to open it directly. Some browsers may restrict local scripts, so running a web server is recommended.
+
+## Usage
+1. Fill in start capital, monthly rate, investment years and interest rate.
+2. Expand **Erweiterte Optionen** to configure rate increases, lump-sum payments, or withdrawals.
+3. Click **Berechnen (Brutto)** for calculations without tax or **Berechnen (Netto)** to include tax.
+4. Review the generated charts and comparison to a savings account.
+
+## Contributing
+Contributions are welcome! Feel free to open issues or submit pull requests.
+
+## Support
+If you run into problems or have questions, open an issue on GitHub.
+


### PR DESCRIPTION
## Summary
- document features of Persoshift ETF calculator
- add setup instructions and ways to run `index.html`
- include basic contribution and support guidelines

## Testing
- `python3 -m http.server` and curl `http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68527c658f0c832fbdb165a1aa6bb9ec