### PR TITLE
Fix missing closing brace in parseHistoricalRates

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,6 +934,7 @@ function parseHistoricalRates(text) {
         rates.push(r);
     }
     return rates;
+}
 
 function computeComparisonTotal(start, lumpsums, baseRate, rateIncrease, annualRate, years, stopEnabled, stopYear) {
     let total = start;


### PR DESCRIPTION
## Summary
- close `parseHistoricalRates` function in `index.html`

## Testing
- `node --check script-temp.js`

------
https://chatgpt.com/codex/tasks/task_e_68528e6e3f98832f9123d0d845108d65